### PR TITLE
fix(security): upgrade axios to ^1.16.1 (CVE-2026-44496)

### DIFF
--- a/Frontend/NBA-Player-Value-Prediction-System/package.json
+++ b/Frontend/NBA-Player-Value-Prediction-System/package.json
@@ -7,7 +7,7 @@
     "@emotion/react": "^11.10.6",
     "@emotion/styled": "^11.10.6",
     "@mui/material": "^5.11.13",
-    "axios": "^1.11.0",
+    "axios": "^1.16.1",
     "cors": "^2.8.5",
     "flask": "^0.2.10",
     "mongoose": "^7.0.3",

--- a/backendnode/package.json
+++ b/backendnode/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "axios": "^1.3.5",
+    "axios": "^1.16.1",
     "body-parser": "^1.20.2",
     "cors": "^2.8.5",
     "express": "^4.18.2",


### PR DESCRIPTION
## Summary

- Upgrades `axios` from `^1.3.5` to `^1.16.1` in `backendnode/package.json`
- Upgrades `axios` from `^1.11.0` to `^1.16.1` in `Frontend/NBA-Player-Value-Prediction-System/package.json`

## Security Advisory

**CVE-2026-44496** — Axios: Regular Expression Denial of Service (ReDoS) via Cookie Name Injection (High severity)

A specially crafted cookie name triggers catastrophic backtracking in axios's cookie-parsing regex, which can block the JavaScript event loop and cause a denial-of-service condition in any app that processes untrusted HTTP responses.

## Fix

Bump `axios` to `^1.16.1` (current latest stable) in both affected sub-projects.

## After merging

Run `npm install` in each sub-directory to regenerate their `package-lock.json` files with the patched version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)